### PR TITLE
Failure to build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,10 +74,10 @@ libraryDependencies ++= Seq(
 )
 
 // Improved incremental compilation
-incOptions := incOptions.value.withNameHashing(true)
+//incOptions := incOptions.value.withNameHashing(true)
 
 // Improved dependency management
-updateOptions := updateOptions.value.withCachedResolution(true)
+//updateOptions := updateOptions.value.withCachedResolution(true)
 
 // Download and create Eclipse source attachments for library dependencies
 // EclipseKeys.withSource := true


### PR DESCRIPTION
```
$ sbt console
...
/home/robin/git/NOEL_MARKHAM/scaladays-2015/build.sbt:77: error: value withNameHashing is not a member of sbt.inc.IncOptions
incOptions := incOptions.value.withNameHashing(true)
                               ^
[error] Type error in expression
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? 
```
